### PR TITLE
Apply go fmt and change how to validate code

### DIFF
--- a/supertest.go
+++ b/supertest.go
@@ -1,217 +1,212 @@
 package supertest
 
-import(
-  "github.com/franela/goreq"
-  "fmt"
-  "io"
-  "strings"
-  "bytes"
-  "encoding/json"
-  "net/url"
-  "io/ioutil"
-  "reflect"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/franela/goreq"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"reflect"
+	"strings"
 )
 
 type Request struct {
-  base string
-  method string
-  path string
-  done reflect.Value
-  body interface{}
-  headers []headerTuple
-  query url.Values
+	base    string
+	method  string
+	path    string
+	done    reflect.Value
+	body    interface{}
+	headers []headerTuple
+	query   url.Values
 }
 
 type headerTuple struct {
-  name string
-  value string
+	name  string
+	value string
 }
 
 func NewRequest(base string) *Request {
-  r := &Request{}
-  r.base = base
-  return r
+	r := &Request{}
+	r.base = base
+	return r
 }
 
-func (r *Request) Get(path string) *Request  {
-  r.method = "GET"
-  r.path = path;
-  return r;
+func (r *Request) Get(path string) *Request {
+	r.method = "GET"
+	r.path = path
+	return r
 }
 
-func (r *Request) Post(path string) *Request  {
-  r.method = "POST"
-  r.path = path;
-  return r;
+func (r *Request) Post(path string) *Request {
+	r.method = "POST"
+	r.path = path
+	return r
 }
 
-func (r *Request) Put(path string) *Request  {
-  r.method = "PUT"
-  r.path = path;
-  return r;
+func (r *Request) Put(path string) *Request {
+	r.method = "PUT"
+	r.path = path
+	return r
 }
 
-func (r *Request) Delete(path string) *Request  {
-  r.method = "DELETE"
-  r.path = path;
-  return r;
+func (r *Request) Delete(path string) *Request {
+	r.method = "DELETE"
+	r.path = path
+	return r
 }
 
-func (r *Request) Patch(path string) *Request  {
-  r.method = "PATCH"
-  r.path = path;
-  return r;
+func (r *Request) Patch(path string) *Request {
+	r.method = "PATCH"
+	r.path = path
+	return r
 }
 
-func (r *Request) Options(path string) *Request  {
-  r.method = "OPTIONS"
-  r.path = path;
-  return r;
+func (r *Request) Options(path string) *Request {
+	r.method = "OPTIONS"
+	r.path = path
+	return r
 }
 
-func (r *Request) Head(path string) *Request  {
-  r.method = "HEAD"
-  r.path = path;
-  return r;
+func (r *Request) Head(path string) *Request {
+	r.method = "HEAD"
+	r.path = path
+	return r
 }
 
 func (r *Request) Send(body interface{}) *Request {
-  r.body = body
-  return r
+	r.body = body
+	return r
 }
 
-
 func (r *Request) Set(name, value string) *Request {
-  r.headers = append(r.headers, headerTuple{name: name, value: value})
-  return r
+	r.headers = append(r.headers, headerTuple{name: name, value: value})
+	return r
 }
 
 func (r *Request) Query(name, value string) *Request {
-  if r.query == nil {
-    r.query = url.Values{}
-  }
-  r.query.Add(name, value)
-  return r
+	if r.query == nil {
+		r.query = url.Values{}
+	}
+	r.query.Add(name, value)
+	return r
 }
 
-func (r *Request) Expect(args ...interface{}) error {
-  if len(args) == 0 {
-    panic("Expect cannot be called without arguments")
-  }
+func (r *Request) Expect(code int, args ...interface{}) error {
 
-  status := args[0].(int)
-  var bodyToCompare interface{}
+	var bodyToCompare interface{}
 
-  if len(args) == 2 {
-    if reflect.ValueOf(args[1]).Kind() == reflect.Func {
-      r.done = reflect.ValueOf(args[1])
-    } else {
-      bodyToCompare = args[1]
-    }
-  }
+	if len(args) == 1 {
+		if reflect.ValueOf(args[0]).Kind() == reflect.Func {
+			r.done = reflect.ValueOf(args[0])
+		} else {
+			bodyToCompare = args[0]
+		}
+	}
 
-  if len(args) == 3 {
-    bodyToCompare = args[1]
-    r.done = reflect.ValueOf(args[2])
-  }
+	if len(args) == 2 {
+		bodyToCompare = args[0]
+		r.done = reflect.ValueOf(args[1])
+	}
 
-  var err error
+	var err error
 
-  var body io.Reader
+	var body io.Reader
 
-  if r.body != nil {
-    body, err = prepareRequestBody(r.body)
-    if err != nil {
-      return err;
-    }
-  }
+	if r.body != nil {
+		body, err = prepareRequestBody(r.body)
+		if err != nil {
+			return err
+		}
+	}
 
-  req := goreq.Request{ Method: r.method, Uri: r.base + r.path + "?" + r.query.Encode(), Body: body }
-  for _, tuple := range(r.headers) {
-    req.AddHeader(tuple.name, tuple.value)
-  }
-  res, e := req.Do()
+	req := goreq.Request{Method: r.method, Uri: r.base + r.path + "?" + r.query.Encode(), Body: body}
+	for _, tuple := range r.headers {
+		req.AddHeader(tuple.name, tuple.value)
+	}
+	res, e := req.Do()
 
-  if e != nil {
-    err = e
-  } else {
-    if res.StatusCode != status {
-      err = fmt.Errorf("Expected %d, was %d", status, res.StatusCode)
-    } else if bodyToCompare != nil {
-      // Read the entire response body
-      b, _ := ioutil.ReadAll(res.Body)
+	if e != nil {
+		err = e
+	} else {
+		if res.StatusCode != code {
+			err = fmt.Errorf("Expected %d, was %d", code, res.StatusCode)
+		} else if bodyToCompare != nil {
+			// Read the entire response body
+			b, _ := ioutil.ReadAll(res.Body)
 
-      if s, ok := bodyToCompare.(string); ok {
-        // It is a string
-        str := string(b)
+			if s, ok := bodyToCompare.(string); ok {
+				// It is a string
+				str := string(b)
 
-        if s != str {
-          err = fmt.Errorf(fmt.Sprintf("%#v", s) + " does not equal " + fmt.Sprintf("%#v", str))
-        }
-      } else {
-        // Try to parse to JSON
-        ptrNewValue := reflect.New(reflect.TypeOf(bodyToCompare))
-        newValue := reflect.Indirect(ptrNewValue)
+				if s != str {
+					err = fmt.Errorf(fmt.Sprintf("%#v", s) + " does not equal " + fmt.Sprintf("%#v", str))
+				}
+			} else {
+				// Try to parse to JSON
+				ptrNewValue := reflect.New(reflect.TypeOf(bodyToCompare))
+				newValue := reflect.Indirect(ptrNewValue)
 
-        e := json.Unmarshal(b, ptrNewValue.Interface())
-        if e != nil {
-          err = fmt.Errorf("Expected: %#v, but got %#v. %s", bodyToCompare, string(b), e)
-        } else {
-          if !objectsAreEqual(bodyToCompare, newValue.Interface()) {
-            err = fmt.Errorf(fmt.Sprintf("%#v", bodyToCompare) + " does not equal " + fmt.Sprintf("%#v", newValue.Interface()))
-          }
-        }
-      }
-    }
-  }
+				e := json.Unmarshal(b, ptrNewValue.Interface())
+				if e != nil {
+					err = fmt.Errorf("Expected: %#v, but got %#v. %s", bodyToCompare, string(b), e)
+				} else {
+					if !objectsAreEqual(bodyToCompare, newValue.Interface()) {
+						err = fmt.Errorf(fmt.Sprintf("%#v", bodyToCompare) + " does not equal " + fmt.Sprintf("%#v", newValue.Interface()))
+					}
+				}
+			}
+		}
+	}
 
-  if r.done.IsValid() {
-    if err != nil {
-      r.done.Call([]reflect.Value {reflect.ValueOf(err)})
-    } else {
-      r.done.Call([]reflect.Value {})
-    }
-  }
-  return err
+	if r.done.IsValid() {
+		if err != nil {
+			r.done.Call([]reflect.Value{reflect.ValueOf(err)})
+		} else {
+			r.done.Call([]reflect.Value{})
+		}
+	}
+	return err
 }
 
 func objectsAreEqual(a, b interface{}) bool {
-  if reflect.DeepEqual(a, b) {
-    return true
-  }
+	if reflect.DeepEqual(a, b) {
+		return true
+	}
 
-  if reflect.ValueOf(a) == reflect.ValueOf(b) {
-    return true
-  }
+	if reflect.ValueOf(a) == reflect.ValueOf(b) {
+		return true
+	}
 
-  if fmt.Sprintf("%#v", a) == fmt.Sprintf("%#v", b) {
-    return true
-  }
+	if fmt.Sprintf("%#v", a) == fmt.Sprintf("%#v", b) {
+		return true
+	}
 
-  return false
+	return false
 }
 
 func prepareRequestBody(b interface{}) (io.Reader, error) {
-  var body io.Reader
+	var body io.Reader
 
-  if sb, ok := b.(string); ok {
-    // treat is as text
-    body = strings.NewReader(sb)
-  } else if rb, ok := b.(io.Reader); ok {
-    // treat is as text
-    body = rb
-  } else if bb, ok := b.([]byte); ok {
-    //treat as byte array
-    body = bytes.NewReader(bb)
-  } else {
-    // try to jsonify it
-    j, err := json.Marshal(b)
-    if err == nil {
-      body = bytes.NewReader(j)
-    } else {
-      return nil, err
-    }
-  }
+	if sb, ok := b.(string); ok {
+		// treat is as text
+		body = strings.NewReader(sb)
+	} else if rb, ok := b.(io.Reader); ok {
+		// treat is as text
+		body = rb
+	} else if bb, ok := b.([]byte); ok {
+		//treat as byte array
+		body = bytes.NewReader(bb)
+	} else {
+		// try to jsonify it
+		j, err := json.Marshal(b)
+		if err == nil {
+			body = bytes.NewReader(j)
+		} else {
+			return nil, err
+		}
+	}
 
-  return body, nil
+	return body, nil
 }

--- a/supertest_test.go
+++ b/supertest_test.go
@@ -1,203 +1,203 @@
 package supertest
 
-import(
-  . "github.com/franela/goblin"
-  "testing"
-  "net/http/httptest"
-  "net/http"
-  "io/ioutil"
-  "encoding/json"
-  "bytes"
+import (
+	"bytes"
+	"encoding/json"
+	. "github.com/franela/goblin"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 func TestSuperTest(t *testing.T) {
-  g := Goblin(t)
+	g := Goblin(t)
 
-  g.Describe("Supertest", func() {
-    g.Describe("Request(url)", func() {
-      g.It("should be supported", func(done Done) {
-        ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-          w.WriteHeader(201)
-          done()
-        }))
-        defer ts.Close()
+	g.Describe("Supertest", func() {
+		g.Describe("Request(url)", func() {
+			g.It("should be supported", func(done Done) {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(201)
+					done()
+				}))
+				defer ts.Close()
 
-        NewRequest(ts.URL).
-          Get("/").Expect(200)
-      })
+				NewRequest(ts.URL).
+					Get("/").Expect(200)
+			})
 
-      g.It("should not panic when there is a connection error", func(done Done) {
-        err := NewRequest("http://127.0.0.0:1111").
-          Get("/").Expect(200)
-        g.Assert(err != nil).IsTrue()
-        done()
-      })
+			g.It("should not panic when there is a connection error", func(done Done) {
+				err := NewRequest("http://127.0.0.0:1111").
+					Get("/").Expect(200)
+				g.Assert(err != nil).IsTrue()
+				done()
+			})
 
-      g.Describe(".Send(interface{})", func() {
-        g.It("should be supported", func(done Done) {
-          var o map[string]string
-          payload := map[string]string { "foo": "bar" }
+			g.Describe(".Send(interface{})", func() {
+				g.It("should be supported", func(done Done) {
+					var o map[string]string
+					payload := map[string]string{"foo": "bar"}
 
-          ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-            if body, err := ioutil.ReadAll(r.Body); err != nil {
-              g.Fail(err)
-              return
-            } else if err := json.Unmarshal(body, &o); err != nil {
-              g.Fail(err)
-              return
-            }
-            g.Assert(o).Equal(payload)
-            done()
-          }))
-          defer ts.Close()
+					ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if body, err := ioutil.ReadAll(r.Body); err != nil {
+							g.Fail(err)
+							return
+						} else if err := json.Unmarshal(body, &o); err != nil {
+							g.Fail(err)
+							return
+						}
+						g.Assert(o).Equal(payload)
+						done()
+					}))
+					defer ts.Close()
 
-          NewRequest(ts.URL).
-            Post("/").
-            Send(payload).
-            Expect(200)
-        })
-      })
+					NewRequest(ts.URL).
+						Post("/").
+						Send(payload).
+						Expect(200)
+				})
+			})
 
-      g.Describe(".Send(string)", func() {
-        g.It("should be supported", func(done Done) {
-          payload := "foo"
+			g.Describe(".Send(string)", func() {
+				g.It("should be supported", func(done Done) {
+					payload := "foo"
 
-          ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-            body, err := ioutil.ReadAll(r.Body)
-            if err != nil {
-              g.Fail(err)
-              return
-            }
-            g.Assert(string(body)).Equal(payload)
-            done()
-          }))
-          defer ts.Close()
+					ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						body, err := ioutil.ReadAll(r.Body)
+						if err != nil {
+							g.Fail(err)
+							return
+						}
+						g.Assert(string(body)).Equal(payload)
+						done()
+					}))
+					defer ts.Close()
 
-          NewRequest(ts.URL).
-            Post("/").
-            Send(payload).
-            Expect(200)
-        })
-      })
+					NewRequest(ts.URL).
+						Post("/").
+						Send(payload).
+						Expect(200)
+				})
+			})
 
-      g.Describe(".Set(string, string)", func() {
-        g.It("should be supported", func(done Done) {
-          ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-            g.Assert(r.Header.Get("foo")).Equal("bar")
-            g.Assert(r.Header.Get("a")).Equal("b")
-            done()
-          }))
-          defer ts.Close()
+			g.Describe(".Set(string, string)", func() {
+				g.It("should be supported", func(done Done) {
+					ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						g.Assert(r.Header.Get("foo")).Equal("bar")
+						g.Assert(r.Header.Get("a")).Equal("b")
+						done()
+					}))
+					defer ts.Close()
 
-          NewRequest(ts.URL).
-            Get("/").
-            Set("foo", "bar").
-            Set("a", "b").
-            Expect(200)
-        })
-      })
+					NewRequest(ts.URL).
+						Get("/").
+						Set("foo", "bar").
+						Set("a", "b").
+						Expect(200)
+				})
+			})
 
-      g.Describe(".Query(string, string)", func() {
-        g.It("should be supported", func(done Done) {
-          ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-            values := r.URL.Query()
+			g.Describe(".Query(string, string)", func() {
+				g.It("should be supported", func(done Done) {
+					ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						values := r.URL.Query()
 
-            g.Assert(values.Get("foo")).Equal("bar")
-            g.Assert(values.Get("a")).Equal("b")
-            done()
-          }))
-          defer ts.Close()
+						g.Assert(values.Get("foo")).Equal("bar")
+						g.Assert(values.Get("a")).Equal("b")
+						done()
+					}))
+					defer ts.Close()
 
-          NewRequest(ts.URL).
-            Get("/").
-            Query("foo", "bar").
-            Query("a", "b").
-            Expect(200)
-        })
-      })
-    })
+					NewRequest(ts.URL).
+						Get("/").
+						Query("foo", "bar").
+						Query("a", "b").
+						Expect(200)
+				})
+			})
+		})
 
-    g.Describe(".Expect(status)", func() {
-      g.It("should be supported", func(done Done) {
-        ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-          w.WriteHeader(204)
-        }))
-        defer ts.Close()
+		g.Describe(".Expect(status)", func() {
+			g.It("should be supported", func(done Done) {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(204)
+				}))
+				defer ts.Close()
 
-        NewRequest(ts.URL).
-          Get("/").
-          Expect(204, done)
-      })
-    })
+				NewRequest(ts.URL).
+					Get("/").
+					Expect(204, done)
+			})
+		})
 
-    g.Describe(".Expect(status, body)", func() {
-      g.It("should assert the response body as json", func(done Done) {
-        payload := map[string]string { "a": "b" }
+		g.Describe(".Expect(status, body)", func() {
+			g.It("should assert the response body as json", func(done Done) {
+				payload := map[string]string{"a": "b"}
 
-        ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-          b, _ := json.Marshal(payload)
-          w.WriteHeader(200)
-          w.Write(b)
-        }))
-        defer ts.Close()
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					b, _ := json.Marshal(payload)
+					w.WriteHeader(200)
+					w.Write(b)
+				}))
+				defer ts.Close()
 
-        NewRequest(ts.URL).
-          Get("/").
-          Expect(200, payload, done)
-      })
+				NewRequest(ts.URL).
+					Get("/").
+					Expect(200, payload, done)
+			})
 
-      g.It("should assert the response body as json using structs", func(done Done) {
-        type Test struct {
-          Foo string
-          Bar string
-        }
+			g.It("should assert the response body as json using structs", func(done Done) {
+				type Test struct {
+					Foo string
+					Bar string
+				}
 
-        payload := Test{ Foo: "foo", Bar: "bar" }
+				payload := Test{Foo: "foo", Bar: "bar"}
 
-        ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-          b, _ := json.Marshal(payload)
-          w.WriteHeader(200)
-          w.Write(b)
-        }))
-        defer ts.Close()
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					b, _ := json.Marshal(payload)
+					w.WriteHeader(200)
+					w.Write(b)
+				}))
+				defer ts.Close()
 
-        NewRequest(ts.URL).
-          Get("/").
-          Expect(200, payload, done)
-      })
+				NewRequest(ts.URL).
+					Get("/").
+					Expect(200, payload, done)
+			})
 
-      g.It("should fail when body is different", func() {
-        type Test struct {
-          Foo string
-          Bar string
-        }
+			g.It("should fail when body is different", func() {
+				type Test struct {
+					Foo string
+					Bar string
+				}
 
-        payload := Test{ Foo: "foo", Bar: "bar" }
+				payload := Test{Foo: "foo", Bar: "bar"}
 
-        ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-          w.WriteHeader(200)
-          w.Write(bytes.NewBufferString("[]").Bytes())
-        }))
-        defer ts.Close()
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(200)
+					w.Write(bytes.NewBufferString("[]").Bytes())
+				}))
+				defer ts.Close()
 
-        err := NewRequest(ts.URL).
-          Get("/").
-          Expect(200, payload)
+				err := NewRequest(ts.URL).
+					Get("/").
+					Expect(200, payload)
 
-        g.Assert(err != nil).IsTrue()
-      })
+				g.Assert(err != nil).IsTrue()
+			})
 
-      g.It("should assert the response body as string", func(done Done) {
-        ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-          w.WriteHeader(200)
-          w.Write(bytes.NewBufferString("foo").Bytes())
-        }))
-        defer ts.Close()
+			g.It("should assert the response body as string", func(done Done) {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(200)
+					w.Write(bytes.NewBufferString("foo").Bytes())
+				}))
+				defer ts.Close()
 
-        NewRequest(ts.URL).
-          Get("/").
-          Expect(200, "foo", done)
-      })
-    })
-  })
+				NewRequest(ts.URL).
+					Get("/").
+					Expect(200, "foo", done)
+			})
+		})
+	})
 }


### PR DESCRIPTION
Go fmt has been applied and Expect now receives two parameters as the previous code was always checking for the first parameter and there was no need to panic
